### PR TITLE
Add 'CacheDir' config option

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -42,13 +42,13 @@ func NewSongCache() *SongCache {
 }
 
 func (c *SongCache) GetNumSongs() int {
-	songs, _ := ioutil.ReadDir(fmt.Sprintf("%s/.mumbledj/songs", dj.homeDir))
+	songs, _ := ioutil.ReadDir(dj.conf.Cache.CacheDir)
 	return len(songs)
 }
 
 func (c *SongCache) GetCurrentTotalFileSize() int64 {
 	var totalSize int64 = 0
-	songs, _ := ioutil.ReadDir(fmt.Sprintf("%s/.mumbledj/songs", dj.homeDir))
+	songs, _ := ioutil.ReadDir(dj.conf.Cache.CacheDir)
 	for _, song := range songs {
 		totalSize += song.Size()
 	}
@@ -70,16 +70,16 @@ func (c *SongCache) Update() {
 
 func (c *SongCache) ClearExpired() {
 	for range time.Tick(5 * time.Minute) {
-		songs, _ := ioutil.ReadDir(fmt.Sprintf("%s/.mumbledj/songs", dj.homeDir))
+		songs, _ := ioutil.ReadDir(dj.conf.Cache.CacheDir)
 		for _, song := range songs {
 			hours := time.Since(song.ModTime()).Hours()
 			if hours >= dj.conf.Cache.ExpireTime {
 				if dj.queue.Len() > 0 {
 					if (dj.queue.CurrentSong().Filename()) != song.Name() {
-						os.Remove(fmt.Sprintf("%s/.mumbledj/songs/%s", dj.homeDir, song.Name()))
+						os.Remove(fmt.Sprintf("%s/%s", dj.conf.Cache.CacheDir, song.Name()))
 					}
 				} else {
-					os.Remove(fmt.Sprintf("%s/.mumbledj/songs/%s", dj.homeDir, song.Name()))
+					os.Remove(fmt.Sprintf("%s/%s", dj.conf.Cache.CacheDir, song.Name()))
 				}
 			}
 		}
@@ -87,15 +87,15 @@ func (c *SongCache) ClearExpired() {
 }
 
 func (c *SongCache) ClearOldest() error {
-	songs, _ := ioutil.ReadDir(fmt.Sprintf("%s/.mumbledj/songs", dj.homeDir))
+	songs, _ := ioutil.ReadDir(dj.conf.Cache.CacheDir)
 	sort.Sort(ByAge(songs))
 	if dj.queue.Len() > 0 {
 		if (dj.queue.CurrentSong().Filename()) != songs[0].Name() {
-			return os.Remove(fmt.Sprintf("%s/.mumbledj/songs/%s", dj.homeDir, songs[0].Name()))
+			return os.Remove(fmt.Sprintf("%s/%s", dj.conf.Cache.CacheDir, songs[0].Name()))
 		} else {
 			return errors.New("Song is currently playing.")
 		}
 	} else {
-		return os.Remove(fmt.Sprintf("%s/.mumbledj/songs/%s", dj.homeDir, songs[0].Name()))
+		return os.Remove(fmt.Sprintf("%s/%s", dj.conf.Cache.CacheDir, songs[0].Name()))
 	}
 }

--- a/commands.go
+++ b/commands.go
@@ -443,11 +443,10 @@ func kill() {
 
 // Deletes songs from ~/.mumbledj/songs.
 func deleteSongs() error {
-	songsDir := fmt.Sprintf("%s/.mumbledj/songs", dj.homeDir)
-	if err := os.RemoveAll(songsDir); err != nil {
+	if err := os.RemoveAll(dj.conf.Cache.CacheDir); err != nil {
 		return errors.New("An error occurred while deleting the audio files.")
 	} else {
-		if err := os.Mkdir(songsDir, 0777); err != nil {
+		if err := os.Mkdir(dj.conf.Cache.CacheDir, 0777); err != nil {
 			return errors.New("An error occurred while recreating the songs directory.")
 		}
 		return nil

--- a/config.gcfg
+++ b/config.gcfg
@@ -40,6 +40,9 @@ MaximumSize = 512
 # DEFAULT VALUE: 24
 ExpireTime = 24
 
+# Directory to store cached songs
+# DEFAULT VALUE: ~/.mumbledj/songs
+CacheDir = ~/.mumbledj/songs
 
 [Volume]
 

--- a/parseconfig.go
+++ b/parseconfig.go
@@ -27,6 +27,7 @@ type DjConfig struct {
 		Enabled     bool
 		MaximumSize int64
 		ExpireTime  float64
+		CacheDir    string
 	}
 	Volume struct {
 		DefaultVolume float32

--- a/service_youtube.go
+++ b/service_youtube.go
@@ -88,8 +88,8 @@ func NewYouTubeSong(user, id string, playlist *YouTubePlaylist) (*YouTubeSong, e
 // Download downloads the song via youtube-dl if it does not already exist on disk.
 // All downloaded songs are stored in ~/.mumbledj/songs and should be automatically cleaned.
 func (s *YouTubeSong) Download() error {
-	if _, err := os.Stat(fmt.Sprintf("%s/.mumbledj/songs/%s", dj.homeDir, s.Filename())); os.IsNotExist(err) {
-		cmd := exec.Command("youtube-dl", "--output", fmt.Sprintf(`~/.mumbledj/songs/%s`, s.Filename()), "--format", "m4a", "--", s.ID())
+	if _, err := os.Stat(fmt.Sprintf("%s/%s", dj.conf.Cache.CacheDir, s.Filename())); os.IsNotExist(err) {
+		cmd := exec.Command("youtube-dl", "--output", fmt.Sprintf(`%s/%s`, dj.conf.Cache.CacheDir, s.Filename()), "--format", "m4a", "--", s.ID())
 		if err := cmd.Run(); err == nil {
 			if dj.conf.Cache.Enabled {
 				dj.cache.CheckMaximumDirectorySize()
@@ -104,7 +104,7 @@ func (s *YouTubeSong) Download() error {
 // Play plays the song. Once the song is playing, a notification is displayed in a text message that features the video
 // thumbnail, URL, title, duration, and submitter.
 func (s *YouTubeSong) Play() {
-	if err := dj.audioStream.Play(fmt.Sprintf("%s/.mumbledj/songs/%s.m4a", dj.homeDir, s.ID()), dj.queue.OnSongFinished); err != nil {
+	if err := dj.audioStream.Play(fmt.Sprintf("%s/%s.m4a", dj.conf.Cache.CacheDir, s.ID()), dj.queue.OnSongFinished); err != nil {
 		panic(err)
 	} else {
 		if s.Playlist() == nil {
@@ -149,7 +149,7 @@ func (s *YouTubeSong) Play() {
 // Delete deletes the song from ~/.mumbledj/songs if the cache is disabled.
 func (s *YouTubeSong) Delete() error {
 	if dj.conf.Cache.Enabled == false {
-		filePath := fmt.Sprintf("%s/.mumbledj/songs/%s.m4a", dj.homeDir, s.ID())
+		filePath := fmt.Sprintf("%s/%s.m4a", dj.conf.Cache.CacheDir, s.ID())
 		if _, err := os.Stat(filePath); err == nil {
 			if err := os.Remove(filePath); err == nil {
 				return nil


### PR DESCRIPTION
This adds a config option so that the user can specify a alternate location to store the cached songs.

This is the first time I've played around with go, so I wasn't sure if the default value should be retrieved with os.GetEnv. However, It works fine with "~"..
