### PR TITLE
Fix for issue #34: !move does not work with sub channels

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -339,10 +339,10 @@ func move(user *gumble.User, channel string) {
 	if channel == "" {
 		dj.SendPrivateMessage(user, NO_ARGUMENT_MSG)
 	} else {
-		if dj.client.Channels.Find(channel) != nil {
-			dj.client.Self.Move(dj.client.Channels.Find(channel))
+		if channels := strings.Split(channel, "/"); dj.client.Channels.Find(channels...) != nil {
+			dj.client.Self.Move(dj.client.Channels.Find(channels...))
 		} else {
-			dj.SendPrivateMessage(user, CHANNEL_DOES_NOT_EXIST_MSG)
+			dj.SendPrivateMessage(user, CHANNEL_DOES_NOT_EXIST_MSG+" "+channel)
 		}
 	}
 }


### PR DESCRIPTION
Hello, I added some features that were useful to me and thought you could use them as well.

Channels must be specified with absolute path and are case sensitive ie for a server with structure:
root
-AFK
-Games
--game1
--game2
-Notgamming
--subchan1
--subchan2

If you'd want to move into game2 you'd have to say
!move Games/game2

I'm not sure how you can retrieve the channel ID mentioned in the issue comments if you don't have edit permissions for the channel

Also added -accesstokens command line argument which can take a list of access tokens separated by a single space