### PR TITLE
Now gives an error message if you have an invalid API key, instead of…

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -203,6 +203,8 @@ func add(user *gumble.User, username, url string) {
 				}
 			} else if fmt.Sprint(err) == "video exceeds the maximum allowed duration." {
 				dj.SendPrivateMessage(user, VIDEO_TOO_LONG_MSG)
+			} else if fmt.Sprint(err) == "Invalid API key supplied." {
+				dj.SendPrivateMessage(user, INVALID_API_KEY)
 			} else {
 				dj.SendPrivateMessage(user, INVALID_YOUTUBE_ID_MSG)
 			}

--- a/strings.go
+++ b/strings.go
@@ -7,6 +7,9 @@
 
 package main
 
+// Message shown to users when the bot has an invalid YouTube API key.
+const INVALID_API_KEY = "MumbleDJ does not have a valid YouTube API key."
+
 // Message shown to users when they do not have permission to execute a command.
 const NO_PERMISSION_MSG = "You do not have permission to execute that command."
 


### PR DESCRIPTION
Currently, if you have an invalid API key (let's say MumbleDJ is running on a machine with a dynamic IP, and you have your API limited to only accept certain addresses), you get the error message "The YouTube URL you supplied did not contain a valid YouTube ID." when you try to add a video to the queue.