### PR TITLE
Fixed cache clearing earlier than expected

### DIFF
--- a/service_youtube.go
+++ b/service_youtube.go
@@ -140,7 +140,7 @@ func NewYouTubeSong(user, id, offset string, playlist *YouTubePlaylist) (*YouTub
 // All downloaded songs are stored in ~/.mumbledj/songs and should be automatically cleaned.
 func (s *YouTubeSong) Download() error {
 	if _, err := os.Stat(fmt.Sprintf("%s/.mumbledj/songs/%s", dj.homeDir, s.Filename())); os.IsNotExist(err) {
-		cmd := exec.Command("youtube-dl", "--output", fmt.Sprintf(`~/.mumbledj/songs/%s`, s.Filename()), "--format", "m4a", "--", s.ID())
+		cmd := exec.Command("youtube-dl", "--no-mtime", "--output", fmt.Sprintf(`~/.mumbledj/songs/%s`, s.Filename()), "--format", "m4a", "--", s.ID())
 		if err := cmd.Run(); err == nil {
 			if dj.conf.Cache.Enabled {
 				dj.cache.CheckMaximumDirectorySize()


### PR DESCRIPTION
By default, the date on a file downloaded by youtube-dl is the date the video was originally uploaded to youtube. As a result, items will always be cleared from the cache because they appear to be years old - even though they were just downloaded. Adding the directive "--no-mtime" will make the date on files the date the file was downloaded.

See this issue on youtube-dl: https://github.com/rg3/youtube-dl/issues/4667