### PR TITLE
Fix possible index out of range when auto shuffle is on

### DIFF
--- a/songqueue.go
+++ b/songqueue.go
@@ -124,10 +124,12 @@ func (q *SongQueue) ShuffleSongs() {
 // Sets a random song as next song to be played
 // queueWasEmpty wether the queue was empty before adding the last song
 func (q *SongQueue) RandomNextSong(queueWasEmpty bool){
-	nextSongIndex := 1
-	if queueWasEmpty{
-		nextSongIndex = 0
+	if (q.Len() > 1){
+		nextSongIndex := 1
+		if queueWasEmpty{
+			nextSongIndex = 0
+		}
+		swapIndex := nextSongIndex + rand.Intn(q.Len() - 1)
+		q.queue[nextSongIndex], q.queue[swapIndex] = q.queue[swapIndex], q.queue[nextSongIndex]
 	}
-	swapIndex := nextSongIndex + rand.Intn(q.Len())
-	q.queue[nextSongIndex], q.queue[swapIndex] = q.queue[swapIndex], q.queue[nextSongIndex]
 }


### PR DESCRIPTION
if rand.Intn(q.Len()) gives q.Len() -1 and there is a son playing we end up with swapIndex = q.Len() which produces an IndexOutOfRange panic.

We must also wrap it inside an if because rand.Intn(0) would also cause a panic.

Sorry for the bug :/