### PR TITLE
Added AnnounceNewTrack config bool

### DIFF
--- a/config.gcfg
+++ b/config.gcfg
@@ -34,6 +34,10 @@ MaxSongPerPlaylist = 50
 # Default Value: false
 AutomaticShuffleOn = false
 
+# Announce song information at start of track
+# Default Value: true
+AnnounceNewTrack = true
+
 [Cache]
 
 # Cache songs as they are downloaded?

--- a/parseconfig.go
+++ b/parseconfig.go
@@ -24,6 +24,7 @@ type DjConfig struct {
 		MaxSongDuration    int
 		MaxSongPerPlaylist int
 		AutomaticShuffleOn bool
+		AnnounceNewTrack   bool
 	}
 	Cache struct {
 		Enabled     bool

--- a/youtube_dl.go
+++ b/youtube_dl.go
@@ -91,7 +91,7 @@ func (dl *AudioTrack) Play() {
 		if !isNil(dl.playlist) {
 			message = fmt.Sprintf(message+`<tr><td align="center">From playlist "%s"</td></tr>`, dl.Playlist().Title())
 		}
-		if dj.conf.General.AnnounceNewTrack == true {
+		if dj.conf.General.AnnounceNewTrack {
 			dj.client.Self.Channel.Send(message+`</table>`, false)
 		}
 		go func() {

--- a/youtube_dl.go
+++ b/youtube_dl.go
@@ -91,8 +91,9 @@ func (dl *AudioTrack) Play() {
 		if !isNil(dl.playlist) {
 			message = fmt.Sprintf(message+`<tr><td align="center">From playlist "%s"</td></tr>`, dl.Playlist().Title())
 		}
-		dj.client.Self.Channel.Send(message+`</table>`, false)
-
+		if dj.conf.General.AnnounceNewTrack == true {
+			dj.client.Self.Channel.Send(message+`</table>`, false)
+		}
 		go func() {
 			dj.audioStream.Wait()
 			dj.queue.OnSongFinished()


### PR DESCRIPTION
Added a new boolean named AnnounceNewTrack that has the ability to disable announcing the song information to the entire channel when the track begins.

This can avoid unnecessary text-to-speech spam when a user adds a track, followed by the bot announcing the song info. The currentsong command fills this gap if users still wants song information. Default is set to true (which is what the bot has been doing previously, so by default, nothing will change).