### PR TITLE
Download "bestaudio" format instead of m4a with youtube-dl

### DIFF
--- a/service_youtube.go
+++ b/service_youtube.go
@@ -91,7 +91,7 @@ func (yt YouTube) NewSong(user *gumble.User, id, offset string, playlist Playlis
 			offset:    int(yt.parseTime(offset, `T\=(?P<days>\d+D)?(?P<hours>\d+H)?(?P<minutes>\d+M)?(?P<seconds>\d+S)?`).Seconds()),
 			duration:  int(yt.parseTime(duration, `P(?P<days>\d+D)?T(?P<hours>\d+H)?(?P<minutes>\d+M)?(?P<seconds>\d+S)?`).Seconds()),
 			thumbnail: thumbnail,
-			format:    "m4a",
+			format:    "bestaudio",
 			skippers:  make([]string, 0),
 			playlist:  playlist,
 			dontSkip:  false,

--- a/youtube_dl.go
+++ b/youtube_dl.go
@@ -167,7 +167,7 @@ func (dl *AudioTrack) ID() string {
 
 // Filename returns the filename of the Song.
 func (dl *AudioTrack) Filename() string {
-	return dl.id + ".m4a"
+	return dl.id + "." + dl.format
 }
 
 // Duration returns duration for the Song.

--- a/youtube_dl.go
+++ b/youtube_dl.go
@@ -167,7 +167,7 @@ func (dl *AudioTrack) ID() string {
 
 // Filename returns the filename of the Song.
 func (dl *AudioTrack) Filename() string {
-	return dl.id + "." + dl.format
+	return dl.id + ".m4a"
 }
 
 // Duration returns duration for the Song.


### PR DESCRIPTION
With youtube-dl's latest 2/10/2016 update it looks like some videos can no longer be downloaded in m4a format.  (For instance https://www.youtube.com/watch?v=nfWlot6h_JM)  Using the "bestaudio" option seems like a good workaround and is currently working for me.   