### PR TITLE
Fix reset panicking on non-empty queue

### DIFF
--- a/bot/queue.go
+++ b/bot/queue.go
@@ -211,22 +211,24 @@ func (q *Queue) Skip() {
 	}
 
 	// Remove all playlist skips if this is the last track of the playlist still in the queue.
-	if playlist := q.Queue[0].GetPlaylist(); playlist != nil {
-		id := playlist.GetID()
-		playlistIsFinished := true
+	if len(q.Queue) > 0 {
+		if playlist := q.Queue[0].GetPlaylist(); playlist != nil {
+			id := playlist.GetID()
+			playlistIsFinished := true
 
-		q.mutex.Unlock()
-		q.Traverse(func(i int, t interfaces.Track) {
-			if i != 0 && t.GetPlaylist() != nil {
-				if t.GetPlaylist().GetID() == id {
-					playlistIsFinished = false
+			q.mutex.Unlock()
+			q.Traverse(func(i int, t interfaces.Track) {
+				if i != 0 && t.GetPlaylist() != nil {
+					if t.GetPlaylist().GetID() == id {
+						playlistIsFinished = false
+					}
 				}
-			}
-		})
-		q.mutex.Lock()
+			})
+			q.mutex.Lock()
 
-		if playlistIsFinished {
-			DJ.Skips.ResetPlaylistSkips()
+			if playlistIsFinished {
+				DJ.Skips.ResetPlaylistSkips()
+			}
 		}
 	}
 

--- a/commands/reset_test.go
+++ b/commands/reset_test.go
@@ -10,6 +10,7 @@ package commands
 import (
 	"testing"
 
+	"github.com/layeh/gumble/gumble"
 	"github.com/layeh/gumble/gumbleffmpeg"
 	"github.com/matthieugrieger/mumbledj/bot"
 	"github.com/spf13/viper"
@@ -43,16 +44,16 @@ func (suite *ResetCommandTestSuite) TestAliases() {
 }
 
 func (suite *ResetCommandTestSuite) TestDescription() {
-	suite.Equal("reset", suite.Command.Description())
+	suite.Equal("Resets the queue by removing all queue items.", suite.Command.Description())
 }
 
 func (suite *ResetCommandTestSuite) TestIsAdminCommand() {
-	suite.False(suite.Command.IsAdminCommand())
+	suite.True(suite.Command.IsAdminCommand())
 }
 
 func (suite *ResetCommandTestSuite) TestResetWorksOnEmpty() {
 	// TODO: Assuming the Queue is currently empty, is that the case?
-	suite.Command.Execute(nil)
+	suite.Command.Execute(new(gumble.User))
 	suite.Zero(DJ.Queue.Length())
 }
 
@@ -62,7 +63,9 @@ func (suite *ResetCommandTestSuite) TestResetWorksOneTrack() {
 	track.Title = "test"
 
 	DJ.Queue.AppendTrack(track)
-	suite.Command.Execute(nil)
+	// If this is non-nil, an error will occur the stream is not valid.
+	DJ.AudioStream = nil
+	suite.Command.Execute(new(gumble.User))
 	suite.Zero(DJ.Queue.Length())
 }
 
@@ -76,8 +79,11 @@ func (suite *ResetCommandTestSuite) TestResetWorksMultipleTracks() {
 
 	DJ.Queue.AppendTrack(track1)
 	DJ.Queue.AppendTrack(track2)
-	suite.Command.Execute(nil)
+	// If this is non-nil, an error will occur the stream is not valid.
+	DJ.AudioStream = nil
+	suite.Command.Execute(new(gumble.User))
 	suite.Zero(DJ.Queue.Length())
+	DJ.AudioStream = new(gumbleffmpeg.Stream)
 }
 
 func TestResetCommandTestSuite(t *testing.T) {

--- a/commands/reset_test.go
+++ b/commands/reset_test.go
@@ -6,3 +6,80 @@
  */
 
 package commands
+
+import (
+	"testing"
+
+	"github.com/layeh/gumble/gumbleffmpeg"
+	"github.com/matthieugrieger/mumbledj/bot"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/suite"
+)
+
+type ResetCommandTestSuite struct {
+	Command ResetCommand
+	suite.Suite
+}
+
+func (suite *ResetCommandTestSuite) SetupSuite() {
+	DJ = bot.NewMumbleDJ()
+	bot.DJ = DJ
+
+	// Trick the tests into thinking audio is already playing to avoid
+	// attempting to play tracks that don't exist.
+	DJ.AudioStream = new(gumbleffmpeg.Stream)
+
+	viper.Set("commands.reset.aliases", []string{"reset", "re"})
+	viper.Set("commands.reset.description", "Resets the queue by removing all queue items.")
+	viper.Set("commands.reset.is_admin", true)
+}
+
+func (suite *ResetCommandTestSuite) SetupTest() {
+	DJ.Queue = bot.NewQueue()
+}
+
+func (suite *ResetCommandTestSuite) TestAliases() {
+	suite.Equal([]string{"reset", "re"}, suite.Command.Aliases())
+}
+
+func (suite *ResetCommandTestSuite) TestDescription() {
+	suite.Equal("reset", suite.Command.Description())
+}
+
+func (suite *ResetCommandTestSuite) TestIsAdminCommand() {
+	suite.False(suite.Command.IsAdminCommand())
+}
+
+func (suite *ResetCommandTestSuite) TestResetWorksOnEmpty() {
+	// TODO: Assuming the Queue is currently empty, is that the case?
+	suite.Command.Execute(nil)
+	suite.Zero(DJ.Queue.Length())
+}
+
+func (suite *ResetCommandTestSuite) TestResetWorksOneTrack() {
+	track := new(bot.Track)
+	track.Submitter = "test"
+	track.Title = "test"
+
+	DJ.Queue.AppendTrack(track)
+	suite.Command.Execute(nil)
+	suite.Zero(DJ.Queue.Length())
+}
+
+func (suite *ResetCommandTestSuite) TestResetWorksMultipleTracks() {
+	track1 := new(bot.Track)
+	track1.Submitter = "test"
+	track1.Title = "test"
+	track2 := new(bot.Track)
+	track2.Submitter = "test"
+	track2.Title = "test"
+
+	DJ.Queue.AppendTrack(track1)
+	DJ.Queue.AppendTrack(track2)
+	suite.Command.Execute(nil)
+	suite.Zero(DJ.Queue.Length())
+}
+
+func TestResetCommandTestSuite(t *testing.T) {
+	suite.Run(t, new(ResetCommandTestSuite))
+}


### PR DESCRIPTION
#### Before submitting this pull request, please acknowledge that you have done the following:
- [x] I have tested my changes to make sure that they work
- [x] I have at least attempted to write relevant unit tests to verify that my changes work
- [x] I have read through the [contribution guidelines](https://github.com/matthieugrieger/mumbledj/blob/master/.github/CONTRIBUTING.md)
- [x] I have written any necessary documentation (for example, adding information about a feature to the README)

---

#### What type of pull request is this?
- [x] Bug fix
- [ ] Typo fix
- [ ] New feature implementation
- [ ] New service implementation
- [ ] Other

---

#### Description of your pull request:
This fixes a bug where reset panics on any non-empty queue. This was because the PlayCurrent function in queue launched a goroutine that waits until the current track is done playing, and then skips. After calling reset, this routine attempted to skip the current a track, causing an error. I added a check in the Skip function to prevent this crash.

I attempted to write the tests for this, but to actually reproduce the bug I think there has to be a valid audio stream so I just tested it manually. In the process I added some basic tests to the reset command, though none of them test this bug.