### PR TITLE
Fix addnext failing on an empty queue

### DIFF
--- a/bot/queue.go
+++ b/bot/queue.go
@@ -85,6 +85,11 @@ func (q *Queue) InsertTrack(i int, t interfaces.Track) error {
 	q.mutex.Lock()
 	beforeLen := len(q.Queue)
 
+	if i < 0 || i > beforeLen {
+		q.mutex.Unlock()
+		return errors.New("Adding at invalid index in queue")
+	}
+
 	// An error should never occur here since maxTrackDuration is restricted to
 	// ints. Any error in the configuration will be caught during yaml load.
 	maxTrackDuration, _ := time.ParseDuration(fmt.Sprintf("%ds",

--- a/commands/addnext.go
+++ b/commands/addnext.go
@@ -75,7 +75,11 @@ func (c *AddNextCommand) Execute(user *gumble.User, args ...string) (string, boo
 	numAdded := 0
 	// We must loop backwards here to preserve the track order when inserting tracks.
 	for i := len(allTracks) - 1; i >= 0; i-- {
-		if err = DJ.Queue.InsertTrack(1, allTracks[i]); err != nil {
+		insertIndex := 1
+		if DJ.Queue.Length() == 0 {
+			insertIndex = 0
+		}
+		if err = DJ.Queue.InsertTrack(insertIndex, allTracks[i]); err != nil {
 			numTooLong++
 		} else {
 			numAdded++

--- a/commands/addnext_test.go
+++ b/commands/addnext_test.go
@@ -6,3 +6,5 @@
  */
 
 package commands
+
+// TODO: Add regression test for bug where addnext fails on an empty queue.


### PR DESCRIPTION
Previously, addnext would try to unconditionally add at index one into a
queue. This panicked if the queue was empty. Added two protections, one
that checks the index in the InsertTrack function, the other in the
addnext command itself to insert at zero if the queue is empty.

#### Before submitting this pull request, please acknowledge that you have done the following:
- [x] I have tested my changes to make sure that they work
- [ ] I have at least attempted to write relevant unit tests to verify that my changes work
- [x] I have read through the [contribution guidelines](https://github.com/matthieugrieger/mumbledj/blob/master/.github/CONTRIBUTING.md)
- [x] I have written any necessary documentation (for example, adding information about a feature to the README)

---

#### What type of pull request is this?
- [x] Bug fix
- [ ] Typo fix
- [ ] New feature implementation
- [ ] New service implementation
- [ ] Other

---

#### Description of your pull request:
Fixes that `addnext` fails on an empty queue. This is because it unconditionally tries to insert at index one, which is out of range for an empty queue. Added a check to return an error if an invalid index is passed. To fix the bug itself, I added an extra case to `addnext` that inserts at zero instead.

I couldn't think of a way to write unit tests for this as it would require passing an actual url to `addnext`. Running it seems to work now, though.